### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: Build and Test
 
+permissions:
+  contents: read
+  pages: write
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/pekkaRo/rust-wasm-typescript-starter/security/code-scanning/1](https://github.com/pekkaRo/rust-wasm-typescript-starter/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. This block will be added at the root level to apply to all jobs unless overridden. Based on the workflow's operations, the minimal required permissions are `contents: read` for accessing repository files and `pages: write` for deploying to GitHub Pages. These permissions will be explicitly defined to limit the scope of the `GITHUB_TOKEN`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
