### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -68,7 +68,9 @@ function setupEventListeners() {
   countWordsBtn.addEventListener('click', () => {
     const text = (document.getElementById('text-input') as HTMLInputElement).value;
     const wordCount = count_words(text);
-    stringResult.innerHTML = `<strong>Word Count:</strong> "${text}" contains ${wordCount} word(s)`;
+    stringResult.innerHTML = `<strong>Word Count:</strong> `;
+    const textNode = document.createTextNode(`"${text}" contains ${wordCount} word(s)`);
+    stringResult.appendChild(textNode);
   });
 
   // Performance operations


### PR DESCRIPTION
Potential fix for [https://github.com/pekkaRo/rust-wasm-typescript-starter/security/code-scanning/4](https://github.com/pekkaRo/rust-wasm-typescript-starter/security/code-scanning/4)

To fix the issue, we need to ensure that the user-provided input (`text`) is properly escaped before being embedded into the HTML. This can be achieved by using a utility function to encode special characters (e.g., `<`, `>`, `&`) into their corresponding HTML entities (e.g., `&lt;`, `&gt;`, `&amp;`). This prevents the browser from interpreting the input as HTML.

The best approach is to replace the use of `innerHTML` with `textContent` for the user-provided input. `textContent` automatically escapes any special characters, ensuring that the input is treated as plain text. For the static HTML structure (e.g., `<strong>Word Count:</strong>`), we can use `innerHTML` safely since it does not involve untrusted input.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
