### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -62,7 +62,7 @@ function setupEventListeners() {
   reverseBtn.addEventListener('click', () => {
     const text = (document.getElementById('text-input') as HTMLInputElement).value;
     const reversed = reverse_string(text);
-    stringResult.innerHTML = `<strong>Reversed:</strong> "${text}" → "${reversed}"`;
+    stringResult.textContent = `Reversed: "${text}" → "${reversed}"`;
   });
 
   countWordsBtn.addEventListener('click', () => {


### PR DESCRIPTION
Potential fix for [https://github.com/pekkaRo/rust-wasm-typescript-starter/security/code-scanning/3](https://github.com/pekkaRo/rust-wasm-typescript-starter/security/code-scanning/3)

To fix the issue, the user input (`text`) should be properly escaped before being inserted into the DOM. Escaping ensures that any special characters in the input are treated as plain text rather than HTML. A safer approach is to use `textContent` instead of `innerHTML` for inserting plain text into the DOM. Alternatively, a utility function can be used to escape HTML characters before assigning the value to `innerHTML`.

The best fix for this snippet is to replace `innerHTML` with `textContent` for the `stringResult` element. This ensures that the user input is treated as plain text, preventing XSS vulnerabilities.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
